### PR TITLE
Require aliases from root

### DIFF
--- a/lib/require.js
+++ b/lib/require.js
@@ -124,7 +124,7 @@ require.register = function(path, fn){
  */
 
 require.alias = function(from, to){
-  var fn = require.modules[from];
+  var fn = require.resolve(from);
   if (!fn) throw new Error('failed to alias "' + from + '", it does not exist');
   require.aliases[to] = from;
 };

--- a/lib/require.js
+++ b/lib/require.js
@@ -56,18 +56,22 @@ require.aliases = {};
  */
 
 require.resolve = function(path){
+  var aliases = require.aliases
+    , modules = require.modules;
   var orig = path
     , reg = path + '.js'
     , regJSON = path + '.json'
     , index = path + '/index.js'
     , indexJSON = path + '/index.json';
 
-  return require.modules[reg] && reg
-    || require.modules[regJSON] && regJSON
-    || require.modules[index] && index
-    || require.modules[indexJSON] && indexJSON
-    || require.modules[orig] && orig
-    || null;
+  return modules[reg] && reg
+    || modules[regJSON] && regJSON
+    || modules[index] && index
+    || modules[indexJSON] && indexJSON
+    || modules[orig] && orig
+    || aliases[reg] || aliases[regJSON]
+    || aliases[index] || aliases[indexJSON]
+    || aliases[orig] || null;
 };
 
 /**


### PR DESCRIPTION
requiring aliased modules only worked with the relative require function.
