### PR TITLE
Replaces array like character access with .charAt

### DIFF
--- a/lib/require.js
+++ b/lib/require.js
@@ -83,7 +83,7 @@ require.normalize = function(curr, path) {
   var segs = [];
 
   // foo
-  if ('.' != path[0]) return path;
+  if ('.' != path.charAt(0)) return path;
 
   curr = curr.split('/');
   path = path.split('/');
@@ -156,7 +156,7 @@ require.relative = function(parent) {
     // resolve deps by returning
     // the dep in the nearest "deps"
     // directory
-    if ('.' != path[0]) {
+    if ('.' != path.charAt(0)) {
       var segs = parent.split('/');
       var i = segs.lastIndexOf('deps') + 1;
       if (!i) i = 0;


### PR DESCRIPTION
Array like access is only standard since ECMAScript 5 and not available in older Browsers like IE6 and IE7
