### PR TITLE
Change require.register signature and fix `require('toString')`

### DIFF
--- a/lib/require.js
+++ b/lib/require.js
@@ -27,7 +27,7 @@ function require(p, parent, orig){
   if (!mod.exports) {
     mod.exports = {};
     mod.client = mod.component = true;
-    mod.call(this, mod, mod.exports, require.relative(path));
+    mod.call(this, require.relative(path), mod.exports, mod);
   }
 
   return mod.exports;

--- a/lib/require.js
+++ b/lib/require.js
@@ -6,52 +6,47 @@
  * @api public
  */
 
-function require(p, parent, orig){
-  var path = require.resolve(p)
-    , mod = require.modules[path];
+function require(path, parent, orig) {
+  var resolved = require.resolve(path);
 
   // lookup failed
-  if (null == path) {
-    orig = orig || p;
+  if (null == resolved) {
+    orig = orig || path;
     parent = parent || 'root';
-    var err = new Error('failed to require "' + orig + '" from "' + parent + '"');
+    var err = new Error('Failed to require "' + orig + '" from "' + parent + '"');
     err.path = orig;
     err.parent = parent;
     err.require = true;
     throw err;
   }
 
+  var module = require.modules[resolved];
+
   // perform real require()
   // by invoking the module's
   // registered function
-  if (!mod.exports) {
-    mod.exports = {};
-    mod.client = mod.component = true;
-    mod.call(this, mod.exports, require.relative(path), mod);
+  if (!module.exports) {
+    module.exports = {};
+    module.client = module.component = true;
+    module.call(this, module.exports, require.relative(resolved), module);
   }
 
-  return mod.exports;
+  return module.exports;
 }
-
-var createEmptyObject = (function() {
-  if (typeof Object.create === 'function') {
-    return function() { return Object.create(null); }
-  } else {
-    return function() { return ({}); }
-  }
-})();
 
 /**
  * Registered modules.
  */
 
-require.modules = createEmptyObject();
+require.modules = {};
 
 /**
  * Registered aliases.
  */
 
-require.aliases = createEmptyObject();
+require.aliases = {};
+
+var has = Object.prototype.hasOwnProperty;
 
 /**
  * Resolve `path`.
@@ -67,19 +62,21 @@ require.aliases = createEmptyObject();
  * @api private
  */
 
-require.resolve = function(path){
+require.resolve = function(path) {
   var orig = path
     , reg = path + '.js'
     , regJSON = path + '.json'
     , index = path + '/index.js'
-    , indexJSON = path + '/index.json';
+    , indexJSON = path + '/index.json'
+    , paths = [reg, regJSON, index, indexJSON, orig]
+    , current;
 
-  return require.modules[reg] && reg
-    || require.modules[regJSON] && regJSON
-    || require.modules[index] && index
-    || require.modules[indexJSON] && indexJSON
-    || require.modules[orig] && orig
-    || require.aliases[index];
+  for (var i = 0, length = paths.length; i < length; i++) {
+    current = paths[i];
+    if (has.call(require.modules, current)) return current;
+  }
+
+  if (has.call(require.aliases, index)) return require.aliases[index];
 };
 
 /**
@@ -111,15 +108,15 @@ require.normalize = function(curr, path) {
 };
 
 /**
- * Register module at `path` with callback `fn`.
+ * Register module at `path` with callback `definition`.
  *
  * @param {String} path
- * @param {Function} fn
+ * @param {Function} definition
  * @api private
  */
 
-require.register = function(path, fn){
-  require.modules[path] = fn;
+require.register = function(path, definition) {
+  require.modules[path] = definition;
 };
 
 /**
@@ -130,9 +127,10 @@ require.register = function(path, fn){
  * @api private
  */
 
-require.alias = function(from, to){
-  var fn = require.modules[from];
-  if (!fn) throw new Error('failed to alias "' + from + '", it does not exist');
+require.alias = function(from, to) {
+  if (!has.call(require.modules, from)) {
+    throw new Error('Failed to alias "' + from + '", it does not exist');
+  }
   require.aliases[to] = from;
 };
 
@@ -151,7 +149,7 @@ require.relative = function(parent) {
    * lastIndexOf helper.
    */
 
-  function lastIndexOf(arr, obj){
+  function lastIndexOf(arr, obj) {
     var i = arr.length;
     while (i--) {
       if (arr[i] === obj) return i;
@@ -163,17 +161,16 @@ require.relative = function(parent) {
    * The relative require() itself.
    */
 
-  function fn(path){
-    var orig = path;
-    path = fn.resolve(path);
-    return require(path, parent, orig);
+  function localRequire(path) {
+    var resolved = localRequire.resolve(path);
+    return require(resolved, parent, path);
   }
 
   /**
    * Resolve relative to the parent.
    */
 
-  fn.resolve = function(path){
+  localRequire.resolve = function(path) {
     // resolve deps by returning
     // the dep in the nearest "deps"
     // directory
@@ -191,9 +188,9 @@ require.relative = function(parent) {
    * Check if module is defined at `path`.
    */
 
-  fn.exists = function(path){
-    return !! require.modules[fn.resolve(path)];
+  localRequire.exists = function(path) {
+    return has.call(require.modules, localRequire.resolve(path));
   };
 
-  return fn;
+  return localRequire;
 };

--- a/lib/require.js
+++ b/lib/require.js
@@ -33,17 +33,25 @@ function require(p, parent, orig){
   return mod.exports;
 }
 
+var createEmptyObject = (function() {
+  if (typeof Object.create === 'function') {
+    return function() { return Object.create(null); }
+  } else {
+    return function() { return ({}); }
+  }
+})();
+
 /**
  * Registered modules.
  */
 
-require.modules = {};
+require.modules = createEmptyObject();
 
 /**
  * Registered aliases.
  */
 
-require.aliases = {};
+require.aliases = createEmptyObject();
 
 /**
  * Resolve `path`.

--- a/lib/require.js
+++ b/lib/require.js
@@ -27,7 +27,7 @@ function require(p, parent, orig){
   if (!mod.exports) {
     mod.exports = {};
     mod.client = mod.component = true;
-    mod.call(this, require.relative(path), mod.exports, mod);
+    mod.call(this, mod.exports, require.relative(path), mod);
   }
 
   return mod.exports;

--- a/test/fixtures/alias-main-boot.js
+++ b/test/fixtures/alias-main-boot.js
@@ -1,5 +1,5 @@
 
-require.register('foo/bar.js', function(module, exports, require){
+require.register('foo/bar.js', function(exports, require, module){
   module.exports = 'foo';
 });
 

--- a/test/fixtures/alias-main.js
+++ b/test/fixtures/alias-main.js
@@ -1,9 +1,9 @@
 
-require.register('foo/index.js', function(module, exports, require){
+require.register('foo/index.js', function(exports, require, module){
   module.exports = require('bar');
 });
 
-require.register('bar/stuff.js', function(module, exports, require){
+require.register('bar/stuff.js', function(exports, require, module){
   module.exports = 'bar';
 });
 

--- a/test/fixtures/alias.js
+++ b/test/fixtures/alias.js
@@ -1,9 +1,9 @@
 
-require.register('foo/index.js', function(module, exports, require){
+require.register('foo/index.js', function(exports, require, module){
   module.exports = require('bar');
 });
 
-require.register('bar/index.js', function(module, exports, require){
+require.register('bar/index.js', function(exports, require, module){
   module.exports = 'bar';
 });
 

--- a/test/fixtures/define.js
+++ b/test/fixtures/define.js
@@ -1,11 +1,11 @@
-require.register('foo', function(module, exports, require){
+require.register('foo', function(exports, require, module){
   exports.foo = 'foo';
 });
 
-require.register('bar', function(module, exports, require){
+require.register('bar', function(exports, require, module){
   module.exports = 'bar';
 });
 
-require.register('baz', function(module, exports, require){
+require.register('baz', function(exports, require, module){
   module.exports = require('bar');
 });

--- a/test/fixtures/deps-error.js
+++ b/test/fixtures/deps-error.js
@@ -1,16 +1,16 @@
 
-require.register('doesnt-exist', function(module, exports, require){
+require.register('doesnt-exist', function(exports, require, module){
   module.exports = 'this shouldnt work';
 });
 
-require.register('foo/index.js', function(module, exports, require){
+require.register('foo/index.js', function(exports, require, module){
   module.exports = require('bar');
 });
 
-require.register('foo/deps/bar', function(module, exports, require){
+require.register('foo/deps/bar', function(exports, require, module){
   module.exports = require('doesnt-exist');
 });
 
-require.register('foo/deps/bar/deps/baz', function(module, exports, require){
+require.register('foo/deps/bar/deps/baz', function(exports, require, module){
   module.exports = 'baz';
 });

--- a/test/fixtures/deps-exists.js
+++ b/test/fixtures/deps-exists.js
@@ -1,19 +1,19 @@
 
-require.register('doesnt-exist', function(module, exports, require){
+require.register('doesnt-exist', function(exports, require, module){
   module.exports = 'this shouldnt work';
 });
 
-require.register('foo/index.js', function(module, exports, require){
+require.register('foo/index.js', function(exports, require, module){
   module.exports = require('bar');
 });
 
-require.register('foo/deps/bar/index.js', function(module, exports, require){
+require.register('foo/deps/bar/index.js', function(exports, require, module){
   module.exports = {
     doesntExist: require.exists('doesnt-exist'),
     baz: require.exists('baz')
   };
 });
 
-require.register('foo/deps/bar/deps/baz', function(module, exports, require){
+require.register('foo/deps/bar/deps/baz', function(exports, require, module){
   module.exports = 'baz';
 });

--- a/test/fixtures/deps.js
+++ b/test/fixtures/deps.js
@@ -1,12 +1,12 @@
 
-require.register('foo/index.js', function(module, exports, require){
+require.register('foo/index.js', function(exports, require, module){
   module.exports = require('bar');
 });
 
-require.register('foo/deps/bar/index.js', function(module, exports, require){
+require.register('foo/deps/bar/index.js', function(exports, require, module){
   module.exports = require('baz');
 });
 
-require.register('foo/deps/bar/deps/baz', function(module, exports, require){
+require.register('foo/deps/bar/deps/baz', function(exports, require, module){
   module.exports = 'baz';
 });

--- a/test/fixtures/error.js
+++ b/test/fixtures/error.js
@@ -1,10 +1,10 @@
 
-require.register('foo/index.js', function(module, exports, require){
+require.register('foo/index.js', function(exports, require, module){
   module.exports = {
     bar: require('./bar')
   }
 });
 
-require.register('foo/bar', function(module, exports, require){
+require.register('foo/bar', function(exports, require, module){
   module.exports = require('./baz');
 });

--- a/test/fixtures/exists.js
+++ b/test/fixtures/exists.js
@@ -1,9 +1,9 @@
 
-require.register('foo/bar/baz', function(module, exports, require){
+require.register('foo/bar/baz', function(exports, require, module){
 
 });
 
-require.register('foo/bar/index.js', function(module, exports, require){
+require.register('foo/bar/index.js', function(exports, require, module){
   module.exports = {
     baz: require.exists('./baz'),
     hey: require.exists('hey')

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -1,15 +1,15 @@
 
-require.register('foo/index.js', function(module, exports, require){
+require.register('foo/index.js', function(exports, require, module){
   module.exports = {
     bar: require('./bar'),
     baz: require('./bar/baz')
   }
 });
 
-require.register('foo/bar/index.js', function(module, exports, require){
+require.register('foo/bar/index.js', function(exports, require, module){
   module.exports = require('./baz');
 });
 
-require.register('foo/bar/baz/index.js', function(module, exports, require){
+require.register('foo/bar/baz/index.js', function(exports, require, module){
   module.exports = 'baz';
 });

--- a/test/fixtures/nested-dep-resolution.js
+++ b/test/fixtures/nested-dep-resolution.js
@@ -1,13 +1,13 @@
 
-require.register('foo/index.js', function(module, exports, require){
+require.register('foo/index.js', function(exports, require, module){
   module.exports = 'foo';
 });
 
-require.register('bar/index.js', function(module, exports, require){
+require.register('bar/index.js', function(exports, require, module){
   module.exports = require('./lib/stuff');
 });
 
-require.register('bar/lib/stuff/index.js', function(module, exports, require){
+require.register('bar/lib/stuff/index.js', function(exports, require, module){
   module.exports = require('foo');
 });
 

--- a/test/fixtures/nested.js
+++ b/test/fixtures/nested.js
@@ -1,15 +1,15 @@
 
-require.register('foo/index.js', function(module, exports, require){
+require.register('foo/index.js', function(exports, require, module){
   module.exports = {
     bar: require('./bar'),
     baz: require('./bar/baz')
   }
 });
 
-require.register('foo/bar/index.js', function(module, exports, require){
+require.register('foo/bar/index.js', function(exports, require, module){
   module.exports = require('./baz');
 });
 
-require.register('foo/bar/baz', function(module, exports, require){
+require.register('foo/bar/baz', function(exports, require, module){
   module.exports = 'baz';
 });

--- a/test/fixtures/prototypal-errors.js
+++ b/test/fixtures/prototypal-errors.js
@@ -1,0 +1,3 @@
+require.register('toString', function(exports, require, module) {
+  exports.stuff = 228;
+});

--- a/test/fixtures/relative.js
+++ b/test/fixtures/relative.js
@@ -1,12 +1,12 @@
 
-require.register('touch/index.js', function(module, exports, require){
+require.register('touch/index.js', function(exports, require, module){
   module.exports = require('./touch/dispatcher');
 });
 
-require.register('touch/touch/dispatcher.js', function(module, exports, require){
+require.register('touch/touch/dispatcher.js', function(exports, require, module){
   module.exports = require('../touch');
 });
 
-require.register('touch/touch.js', function(module, exports, require){
+require.register('touch/touch.js', function(exports, require, module){
   module.exports = 'touch';
 });

--- a/test/require.js
+++ b/test/require.js
@@ -73,7 +73,7 @@ describe('require.register(name, fn)', function(){
       var js = fixture('error.js');
       var ret = eval(js + 'require("foo")', {});
     } catch (err) {
-      err.message.should.equal('failed to require "./baz" from "foo/bar"');
+      err.message.should.equal('Failed to require "./baz" from "foo/bar"');
       done();
     }
   })
@@ -83,9 +83,16 @@ describe('require.register(name, fn)', function(){
       var js = fixture('deps-error.js');
       var ret = eval(js + 'require("foo")', {});
     } catch (err) {
-      err.message.should.equal('failed to require "doesnt-exist" from "foo/deps/bar"');
+      err.message.should.equal('Failed to require "doesnt-exist" from "foo/deps/bar"');
       done();
     }
+  })
+
+  it('should not be confused by prototypal inheritance', function() {
+    var js = fixture('prototypal-errors.js');
+    (function() { eval(js + 'require("constructor")', {}); }).should.throwError();
+    var ret = eval(js + 'require("toString")', {});
+    ret.stuff.should.equal(228);
   })
 })
 

--- a/test/require.js
+++ b/test/require.js
@@ -6,7 +6,8 @@
 var fs = require('fs')
   , vm = require('vm')
   , r = require('..')
-  , read = fs.readFileSync;
+  , read = fs.readFileSync
+  , should = require('should');
 
 function fixture(name) {
   return read('test/fixtures/' + name, 'utf8');
@@ -25,7 +26,7 @@ describe('require.register(name, fn)', function(){
   it('should define a module', function(){
     var js = fixture('define.js');
     var ret = eval(js + 'require("foo")', {});
-    ret.foo.should.equal('foo');
+    should.equal(ret.foo, 'foo');
   })
 
   it('should support module.exports', function(){

--- a/test/require.js
+++ b/test/require.js
@@ -26,6 +26,7 @@ describe('require.register(name, fn)', function(){
   it('should define a module', function(){
     var js = fixture('define.js');
     var ret = eval(js + 'require("foo")', {});
+    console.log(ret)
     should.equal(ret.foo, 'foo');
   })
 


### PR DESCRIPTION
1. `require.register` sig was changed from `module, exports, require` to `exports, require, module` to match node.js and other implementations.
2. Fixed bugs like `require('toString')`, `require('hasOwnProperty')`.

In IE<=8 the bug will still exist, but more global check will require a lot more code. This will slightly encourage people to upgrade.
