### PR TITLE
add support for exporting falsey values

### DIFF
--- a/test/fixtures/falsey.js
+++ b/test/fixtures/falsey.js
@@ -1,0 +1,8 @@
+
+require.register('false', function(exports, require, module){
+  module.exports = false;
+});
+
+require.register('zero', function(exports, require, module){
+  module.exports = 0;
+});

--- a/test/require.js
+++ b/test/require.js
@@ -36,6 +36,14 @@ describe('require.register(name, fn)', function(){
     ret.should.equal('bar');
   })
 
+  it('should support exporting falsey values', function () {
+    var js = fixture('falsey.js');
+    var ret = eval(js + 'require("false")', {});
+    ret.should.equal(false);
+    var ret = eval(js + 'require("zero")', {});
+    ret.should.equal(0);
+  })
+
   it('should support nested require()s', function(){
     var js = fixture('nested.js');
     var ret = eval(js + 'require("foo")', {});


### PR DESCRIPTION
i'd like the ability to export `false` rather than a function which returns false.  for example:

**export-boolean.js**:

``` js
var has = feature_detect()

module.exports = has
```

rather than:

**export-function-which-returns-boolean.js**:

``` js

var has = feature_detect()

module.exports = function(){
  return has
}

```
