### PR TITLE
Fix circular dependency issue

### DIFF
--- a/lib/require.js
+++ b/lib/require.js
@@ -26,11 +26,13 @@ function require(path, parent, orig) {
   // perform real require()
   // by invoking the module's
   // registered function
-  if (!module.exports) {
+  if (!module._resolving && !module.exports) {
     var mod = {};
     mod.exports = {};
     mod.client = mod.component = true;
+    module._resolving = true;
     module.call(this, mod.exports, require.relative(resolved), mod);
+    delete module._resolving;
     module.exports = mod.exports;
   }
 

--- a/test/fixtures/circular.js
+++ b/test/fixtures/circular.js
@@ -1,0 +1,19 @@
+var counter = {
+  foo: 0,
+  bar: 0
+};
+
+require.register('index', function(exports, require, module){
+  module.exports = require('./foo');
+  require('./bar');
+});
+
+require.register('foo', function(exports, require, module){
+  exports.bar = require('./bar').bar;
+  exports.foo = ++counter.foo;
+});
+
+require.register('bar', function(exports, require, module){
+  require('./foo');
+  exports.bar = ++counter.bar;
+});

--- a/test/require.js
+++ b/test/require.js
@@ -100,6 +100,13 @@ describe('require.register(name, fn)', function(){
     var ret = eval(js + 'require("meh")', {});
     ret.should.equal('hi');
   })
+
+  it('should support circular dependencies', function(){
+    var js = fixture('circular.js');
+    var ret = eval(js + 'require("index")', {});
+    ret.foo.should.equal(1);
+    ret.bar.should.equal(1);
+  })
 })
 
 describe('require.normalize(curr, path)', function(){


### PR DESCRIPTION
Test is in a separate commit in case someone finds a better fix.
This fix adds a `_resolving` flag to break a dependency circle.
More on this in [component google group](https://groups.google.com/d/msg/componentjs/FTYUmzG3zdc/saKET6zmxfwJ)
