### PR TITLE
Require returns the actual module.exports object

### DIFF
--- a/lib/require.js
+++ b/lib/require.js
@@ -1,4 +1,3 @@
-
 /**
  * Require the given path.
  *
@@ -23,17 +22,11 @@ function require(path, parent, orig) {
 
   var module = require.modules[resolved];
 
-  // perform real require()
-  // by invoking the module's
-  // registered function
-  if (!module._resolving && !module.exports) {
-    var mod = {};
-    mod.exports = {};
-    mod.client = mod.component = true;
-    module._resolving = true;
-    module.call(this, mod.exports, require.relative(resolved), mod);
-    delete module._resolving;
-    module.exports = mod.exports;
+  if (!module.exports) {
+    module.exports = {};
+    module.client = module.component = true;
+    module.definition.call(this, module.exports, require.relative(resolved), module);
+    delete module.definition;
   }
 
   return module.exports;
@@ -120,7 +113,9 @@ require.normalize = function(curr, path) {
  */
 
 require.register = function(path, definition) {
-  require.modules[path] = definition;
+  require.modules[path] = {
+    definition: definition
+  };
 };
 
 /**

--- a/test/fixtures/circular.js
+++ b/test/fixtures/circular.js
@@ -3,17 +3,24 @@ var counter = {
   bar: 0
 };
 
-require.register('index', function(exports, require, module){
+require.register('index', function(exports, require, module) {
   module.exports = require('./foo');
   require('./bar');
 });
 
-require.register('foo', function(exports, require, module){
+require.register('foo', function(exports, require, module) {
   exports.bar = require('./bar').bar;
   exports.foo = ++counter.foo;
+
+  require('./baz');
 });
 
-require.register('bar', function(exports, require, module){
-  require('./foo');
+require.register('bar', function(exports, require, module) {
+  var foo = require('./foo');
   exports.bar = ++counter.bar;
+});
+
+require.register('baz', function(exports, require, module) {
+  var foo = require('./foo');
+  foo.baz = foo.bar + 1;
 });

--- a/test/require.js
+++ b/test/require.js
@@ -106,6 +106,13 @@ describe('require.register(name, fn)', function(){
     ret.foo.should.equal(1);
     ret.bar.should.equal(1);
   })
+
+  it('should always return the actual value of module.exports', function() {
+    var js = fixture('circular.js');
+    var ret = eval(js + 'require("index")', {});
+
+    ret.baz.should.equal(2);
+  });
 })
 
 describe('require.normalize(curr, path)', function(){


### PR DESCRIPTION
The current implementation is using a temporary object, breaking compatibility with node's require and making some pure nodejs components to stop working (see #30).

Node's require always returns a valid module.exports value, like component/require@0.2.2 was doing. This pull uses that original implementation plus a change to allow typeof module to be "object".

The difference with #31, which solves the same issue, is that this change does not rely on temporary objects or caches.
